### PR TITLE
Add Next.js migration planning documentation

### DIFF
--- a/docs/start/1_nextjs_implementation.md
+++ b/docs/start/1_nextjs_implementation.md
@@ -1,0 +1,699 @@
+# Next.js 정적 사이트 전환 - 구현 가이드
+
+> **관련 문서**: [1_nextjs_prd.md](./1_nextjs_prd.md) | [1_nextjs_todo.md](./1_nextjs_todo.md)
+
+## 프로젝트 구조
+
+```
+v2.advenoh.pe.kr/
+├── app/                      # Next.js App Router
+│   ├── layout.tsx           # Root layout
+│   ├── page.tsx             # 홈 페이지
+│   ├── not-found.tsx        # 404 페이지
+│   └── globals.css          # 전역 스타일
+├── components/              # React 컴포넌트
+│   ├── Header.tsx
+│   ├── Footer.tsx           # 신규
+│   ├── PortfolioCard.tsx
+│   ├── theme-provider.tsx
+│   └── ui/                  # shadcn/ui 컴포넌트
+├── lib/                     # 유틸리티 및 설정
+│   ├── utils.ts
+│   ├── site-config.ts       # 신규
+│   └── portfolio.ts         # 신규 - 포트폴리오 데이터 로더
+├── contents/
+│   └── website/             # 마크다운 포트폴리오 파일
+├── public/                  # 정적 자산
+├── next.config.js
+├── netlify.toml             # 신규
+├── tailwind.config.js
+├── tsconfig.json
+└── package.json
+```
+
+## 1. Next.js 프로젝트 초기화
+
+### 1.1 Next.js 설치
+
+```bash
+# Next.js 14 설치 (TypeScript, Tailwind CSS, App Router)
+npx create-next-app@latest . --typescript --tailwind --app --no-src-dir
+
+# 또는 기존 프로젝트에서 수동 설치
+npm install next@14 react@18 react-dom@18
+```
+
+### 1.2 next.config.js 설정
+
+```javascript
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',  // 정적 사이트 생성
+  images: {
+    unoptimized: true  // 정적 호스팅용 (Netlify에서 이미지 최적화 불필요)
+  },
+  // 경로 별칭은 tsconfig.json에서 관리
+}
+
+module.exports = nextConfig
+```
+
+### 1.3 tsconfig.json 설정
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}
+```
+
+### 1.4 Tailwind CSS 설정
+
+```javascript
+// tailwind.config.js
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ["class"],  // next-themes 호환
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+        heading: ['Space Grotesk', 'sans-serif'],
+      },
+      // 기존 커스텀 컬러 및 테마 설정 유지
+    },
+  },
+  plugins: [require("tailwindcss-animate")],
+}
+```
+
+## 2. 핵심 라이브러리 설치
+
+### 2.1 필수 패키지
+
+```bash
+# Next.js 및 React
+npm install next@14 react@18 react-dom@18
+
+# 테마 시스템
+npm install next-themes
+
+# 마크다운 처리
+npm install gray-matter
+
+# 폰트 최적화 (Next.js 내장)
+# next/font 사용
+
+# 기존 UI 라이브러리 (유지)
+# - lucide-react
+# - @radix-ui/*
+# - class-variance-authority
+# - clsx
+# - tailwind-merge
+```
+
+### 2.2 개발 도구
+
+```bash
+# Netlify CLI
+npm install -D netlify-cli
+
+# TypeScript 및 Tailwind (이미 설치됨)
+# - typescript
+# - tailwindcss
+# - @types/node
+# - @types/react
+# - @types/react-dom
+```
+
+## 3. 사이트 설정 파일
+
+### 3.1 lib/site-config.ts
+
+```typescript
+export const siteConfig = {
+  name: "Frank Oh Portfolio",
+  description: "Portfolio website showcasing web development projects",
+  url: "https://advenoh.pe.kr",
+  author: {
+    name: "Frank Oh",
+    email: "your-email@example.com", // 선택적
+    social: {
+      instagram: "https://www.instagram.com/frank.photosnap/",
+      linkedin: "https://www.linkedin.com/in/frank-oh-abb80b10/",
+      github: "https://github.com/kenshin579"
+    }
+  }
+} as const
+
+export type SiteConfig = typeof siteConfig
+```
+
+## 4. 포트폴리오 데이터 로더
+
+### 4.1 lib/portfolio.ts
+
+```typescript
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+import { z } from 'zod'
+
+// Zod 스키마 (기존 shared/schema.ts에서 이전)
+export const portfolioItemSchema = z.object({
+  site: z.string().url(),
+  title: z.string().optional(),
+  description: z.string(),
+})
+
+export type PortfolioItem = z.infer<typeof portfolioItemSchema> & {
+  slug: string
+}
+
+/**
+ * contents/website/ 디렉토리에서 모든 포트폴리오 항목 로드
+ */
+export function getPortfolioItems(): PortfolioItem[] {
+  const contentsDir = path.join(process.cwd(), 'contents/website')
+
+  // 디렉토리가 없으면 빈 배열 반환
+  if (!fs.existsSync(contentsDir)) {
+    console.warn('Portfolio contents directory not found:', contentsDir)
+    return []
+  }
+
+  const files = fs.readdirSync(contentsDir)
+  const mdFiles = files.filter(file => file.endsWith('.md'))
+
+  const items = mdFiles.map(filename => {
+    const filePath = path.join(contentsDir, filename)
+    const fileContents = fs.readFileSync(filePath, 'utf8')
+    const { data } = matter(fileContents)
+
+    // Zod로 검증
+    const validated = portfolioItemSchema.parse(data)
+
+    // title이 없으면 URL에서 추출
+    const title = validated.title || extractTitleFromUrl(validated.site)
+
+    return {
+      ...validated,
+      title,
+      slug: filename.replace('.md', ''),
+    }
+  })
+
+  // 파일명 기준 정렬 (기존 로직 유지)
+  return items.sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
+/**
+ * URL에서 타이틀 추출 (기존 로직)
+ */
+function extractTitleFromUrl(url: string): string {
+  try {
+    const hostname = new URL(url).hostname
+    return hostname.replace('www.', '').split('.')[0]
+  } catch {
+    return 'Untitled'
+  }
+}
+```
+
+## 5. 컴포넌트 구현
+
+### 5.1 app/layout.tsx (Root Layout)
+
+```tsx
+import type { Metadata } from 'next'
+import { Inter, Space_Grotesk } from 'next/font/google'
+import { ThemeProvider } from '@/components/theme-provider'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import './globals.css'
+import { siteConfig } from '@/lib/site-config'
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-sans',
+})
+
+const spaceGrotesk = Space_Grotesk({
+  subsets: ['latin'],
+  variable: '--font-heading',
+})
+
+export const metadata: Metadata = {
+  title: siteConfig.name,
+  description: siteConfig.description,
+  authors: [{ name: siteConfig.author.name }],
+  openGraph: {
+    type: 'website',
+    locale: 'ko_KR',
+    url: siteConfig.url,
+    title: siteConfig.name,
+    description: siteConfig.description,
+    siteName: siteConfig.name,
+  },
+  // Structured Data는 별도 컴포넌트로 추가
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="ko" suppressHydrationWarning>
+      <body className={`${inter.variable} ${spaceGrotesk.variable} font-sans`}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <div className="flex min-h-screen flex-col">
+            <Header />
+            <main className="flex-1">
+              {children}
+            </main>
+            <Footer />
+          </div>
+        </ThemeProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+### 5.2 app/page.tsx (홈 페이지)
+
+```tsx
+import { getPortfolioItems } from '@/lib/portfolio'
+import PortfolioCard from '@/components/PortfolioCard'
+
+export default function HomePage() {
+  const portfolioItems = getPortfolioItems()
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <section className="mb-12">
+        <h1 className="font-heading text-4xl font-bold mb-4">
+          Portfolio
+        </h1>
+        <p className="text-muted-foreground">
+          A collection of web development projects
+        </p>
+      </section>
+
+      <section>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {portfolioItems.map(item => (
+            <PortfolioCard
+              key={item.slug}
+              title={item.title}
+              description={item.description}
+              url={item.site}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}
+```
+
+### 5.3 app/not-found.tsx (404 페이지)
+
+```tsx
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+
+export default function NotFound() {
+  return (
+    <div className="container mx-auto px-4 py-20 text-center">
+      <h1 className="font-heading text-6xl font-bold mb-4">404</h1>
+      <p className="text-xl text-muted-foreground mb-8">
+        Page not found
+      </p>
+      <Button asChild>
+        <Link href="/">
+          Go Home
+        </Link>
+      </Button>
+    </div>
+  )
+}
+```
+
+### 5.4 components/Header.tsx
+
+```tsx
+'use client'
+
+import Link from 'next/link'
+import { MoonIcon, SunIcon } from 'lucide-react'
+import { useTheme } from 'next-themes'
+import { Button } from '@/components/ui/button'
+
+export default function Header() {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="container mx-auto flex h-16 items-center justify-between px-4">
+        <Link href="/" className="font-heading text-xl font-bold">
+          Frank Oh
+        </Link>
+
+        <nav className="flex items-center gap-4">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            aria-label="Toggle theme"
+          >
+            <SunIcon className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+            <MoonIcon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          </Button>
+        </nav>
+      </div>
+    </header>
+  )
+}
+```
+
+### 5.5 components/Footer.tsx (신규)
+
+```tsx
+import Link from 'next/link'
+import { Instagram, Linkedin, Github } from 'lucide-react'
+import { siteConfig } from '@/lib/site-config'
+
+export default function Footer() {
+  const currentYear = new Date().getFullYear()
+
+  return (
+    <footer className="border-t bg-background">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
+          <p className="text-sm text-muted-foreground">
+            © {currentYear} {siteConfig.author.name}. All rights reserved.
+          </p>
+
+          <div className="flex items-center gap-4">
+            <Link
+              href={siteConfig.author.social.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Github className="h-5 w-5" />
+            </Link>
+            <Link
+              href={siteConfig.author.social.linkedin}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Linkedin className="h-5 w-5" />
+            </Link>
+            <Link
+              href={siteConfig.author.social.instagram}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Instagram className="h-5 w-5" />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </footer>
+  )
+}
+```
+
+### 5.6 components/PortfolioCard.tsx
+
+```tsx
+import Link from 'next/link'
+import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { ExternalLink } from 'lucide-react'
+
+interface PortfolioCardProps {
+  title: string
+  description: string
+  url: string
+}
+
+export default function PortfolioCard({ title, description, url }: PortfolioCardProps) {
+  return (
+    <Link href={url} target="_blank" rel="noopener noreferrer">
+      <Card className="h-full transition-all duration-200 hover:scale-105 hover:shadow-lg">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            {title}
+            <ExternalLink className="h-4 w-4" />
+          </CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+      </Card>
+    </Link>
+  )
+}
+```
+
+### 5.7 components/theme-provider.tsx
+
+```tsx
+'use client'
+
+import * as React from 'react'
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import { type ThemeProviderProps } from 'next-themes/dist/types'
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}
+```
+
+## 6. Netlify 배포 설정
+
+### 6.1 netlify.toml
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "out"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+
+# 404 페이지 리다이렉트
+[[redirects]]
+  from = "/*"
+  to = "/404.html"
+  status = 404
+```
+
+### 6.2 package.json 스크립트
+
+```json
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
+  }
+}
+```
+
+## 7. shadcn/ui 재설치
+
+### 7.1 components.json 설정
+
+```json
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}
+```
+
+### 7.2 필요한 shadcn/ui 컴포넌트 설치
+
+```bash
+npx shadcn-ui@latest init
+npx shadcn-ui@latest add button
+npx shadcn-ui@latest add card
+npx shadcn-ui@latest add dropdown-menu
+```
+
+## 8. 테스트 전략
+
+### 8.1 MCP Playwright 테스트 시나리오
+
+**테스트 파일**: `tests/portfolio.spec.ts` (향후 작성)
+
+테스트 항목:
+1. **포트폴리오 카드 렌더링**
+   - 카드 개수 확인
+   - 제목, 설명 표시 확인
+
+2. **테마 전환**
+   - 테마 토글 버튼 클릭
+   - 다크/라이트 모드 전환 확인
+
+3. **반응형 레이아웃**
+   - 모바일 (375px): 1열 그리드
+   - 태블릿 (768px): 2열 그리드
+   - 데스크톱 (1024px): 3열 그리드
+
+4. **Footer SNS 링크**
+   - Instagram, LinkedIn, GitHub 링크 존재
+   - 올바른 URL 확인
+   - `target="_blank"` 속성 확인
+
+5. **접근성**
+   - 키보드 네비게이션 (Tab, Enter)
+   - ARIA 레이블 확인
+
+## 9. 빌드 및 배포
+
+### 9.1 로컬 빌드 테스트
+
+```bash
+# 빌드
+npm run build
+
+# 빌드 결과 확인
+ls -la out/
+
+# Netlify 로컬 테스트 (선택적)
+npx netlify dev
+```
+
+### 9.2 Netlify 배포
+
+```bash
+# Netlify 로그인
+npx netlify login
+
+# 사이트 초기화
+npx netlify init
+
+# 배포 (프로덕션)
+npx netlify deploy --prod
+```
+
+## 10. 클린업 작업
+
+### 10.1 제거할 디렉토리 및 파일
+
+```bash
+# 서버 디렉토리
+rm -rf server/
+
+# 클라이언트 디렉토리 (내용 이전 후)
+# client/src/ 내용을 app/, components/로 이동 후 제거
+
+# 설정 파일
+rm vite.config.ts
+rm drizzle.config.ts
+
+# 미사용 의존성 제거
+npm uninstall express vite @vitejs/plugin-react drizzle-orm @neondatabase/serverless
+```
+
+### 10.2 package.json 정리
+
+제거할 패키지:
+- `express`
+- `vite`
+- `@vitejs/plugin-react`
+- `drizzle-orm`
+- `@neondatabase/serverless`
+- 기타 서버 관련 패키지
+
+## 11. 최종 검증
+
+### 11.1 빌드 성공 확인
+
+```bash
+npm run build
+# ✓ 정적 파일이 out/ 디렉토리에 생성되었는지 확인
+```
+
+### 11.2 로컬 테스트
+
+```bash
+# 정적 파일 서버 (예: serve)
+npx serve out
+
+# 브라우저에서 확인:
+# - http://localhost:3000
+# - 포트폴리오 카드 표시
+# - 테마 전환 동작
+# - SNS 링크 동작
+```
+
+### 11.3 Playwright E2E 테스트 실행
+
+```bash
+# Playwright 테스트 (todo.md 완료 후)
+npx playwright test
+```
+
+---
+
+**다음 단계**: [1_nextjs_todo.md](./1_nextjs_todo.md) 체크리스트 참조

--- a/docs/start/1_nextjs_prd.md
+++ b/docs/start/1_nextjs_prd.md
@@ -1,0 +1,430 @@
+# Next.js 정적 사이트 전환 PRD
+
+## 프로젝트 개요
+
+현재 Express + Vite 기반의 풀스택 애플리케이션을 Next.js 기반의 정적 사이트(SSG)로 전환합니다.
+
+### 전환 목표
+- **서버리스 배포**: 서버 구동 없이 정적 파일만으로 호스팅 가능
+- **성능 최적화**: SSG를 통한 빠른 페이지 로딩
+- **간소화된 아키텍처**: 백엔드 제거, 프론트엔드 중심 구조
+- **개발 경험 개선**: Next.js의 파일 기반 라우팅 및 최적화 활용
+
+## 현재 아키텍처 분석
+
+### 제거 대상
+- `server/` 디렉토리 전체 (Express 백엔드)
+  - `index.ts` - Express 서버
+  - `routes.ts` - API 라우트
+  - `vite.ts` - Vite 개발 서버 통합
+  - `storage.ts` - Drizzle ORM (현재 미사용)
+
+### 마이그레이션 대상
+- `client/` 디렉토리
+  - `src/components/` - React 컴포넌트들 → Next.js 컴포넌트로 전환
+  - `src/pages/` - 페이지 컴포넌트들 → Next.js App Router 또는 Pages Router
+  - `src/hooks/` - Custom hooks (그대로 유지 가능)
+  - `src/lib/` - 유틸리티 함수들 (그대로 유지)
+
+### 유지/활용 대상
+- `contents/website/` - 마크다운 기반 포트폴리오 콘텐츠
+  - Next.js에서 빌드 타임에 파싱하여 정적 페이지 생성
+- `shared/schema.ts` - Zod 스키마 (데이터 검증용으로 유지)
+- Tailwind CSS + shadcn/ui 설정
+- 테마 시스템 (다크/라이트 모드)
+
+## 기술 스택
+
+### Next.js 설정
+- **버전**: Next.js 14+ (App Router 권장)
+- **렌더링 전략**: Static Site Generation (SSG)
+- **라우팅**: App Router (`app/` 디렉토리)
+- **TypeScript**: 기존 설정 유지
+
+### 유지되는 스택
+- **스타일링**: Tailwind CSS v3
+- **UI 컴포넌트**: shadcn/ui (Radix UI)
+- **타입 체크**: Zod schemas
+- **폰트**: Inter (body), Space Grotesk (headings)
+
+### 새로 추가되는 도구
+- **마크다운 처리**:
+  - `gray-matter` (frontmatter 파싱, 기존 사용 중)
+  - `next-mdx-remote` 또는 `@next/mdx` (선택적, 향후 MDX 지원용)
+- **이미지 최적화**: Next.js Image 컴포넌트
+
+### 개발 도구 및 MCP 서버 활용
+- **MCP Context7**: 라이브러리 최신 문서 및 베스트 프랙티스 참조
+  - Next.js, React, Tailwind CSS 공식 패턴
+  - next-themes, shadcn/ui 사용법
+  - 버전별 마이그레이션 가이드
+- **MCP Playwright**: E2E 테스트 및 브라우저 자동화
+  - 포트폴리오 카드 렌더링 검증
+  - 테마 전환 동작 테스트
+  - 반응형 레이아웃 시각적 검증
+  - 접근성 자동화 테스트 (WCAG 준수)
+
+## 주요 기능 요구사항
+
+### 1. 포트폴리오 시스템 (필수)
+현재 `/api/portfolio` 엔드포인트가 제공하는 기능을 정적으로 구현:
+
+- **데이터 소스**: `contents/website/*.md` 파일들
+- **빌드 타임 처리**:
+  - 모든 마크다운 파일을 읽고 frontmatter 파싱
+  - `portfolioItemSchema`로 검증
+  - 정적 데이터로 변환하여 페이지에 주입
+
+- **Frontmatter 스키마** (유지):
+  ```markdown
+  ---
+  site: https://example.com  # Required
+  title: Project Title        # Optional
+  description: Brief desc     # Required
+  ---
+  ```
+
+- **정렬**: 파일명 기준 정렬 (현재 로직 유지)
+
+### 2. 페이지 구조
+
+#### 홈 페이지 (`/`)
+- 현재 `client/src/pages/Home.tsx` 내용 마이그레이션
+- 포트폴리오 카드 그리드 표시
+- 반응형 레이아웃: 1열(모바일) → 2열(태블릿) → 3열(데스크톱)
+
+#### 404 페이지 (`/404`)
+- 현재 `client/src/pages/NotFound.tsx` 내용 마이그레이션
+
+#### 향후 확장 가능성
+- 개별 포트폴리오 상세 페이지 (`/portfolio/[slug]`)
+  - 현재 마크다운 body 콘텐츠는 미사용이지만 향후 활용 가능
+  - Dynamic routes로 구현 준비
+
+### 3. 컴포넌트 마이그레이션
+
+#### 필수 컴포넌트
+- **Header** (`components/Header.tsx`)
+  - 네비게이션
+  - 테마 토글 버튼
+  - **SNS 링크**: Instagram, LinkedIn, GitHub (선택적 표시)
+
+- **Footer** (`components/Footer.tsx`) - 신규 추가
+  - 저작권 정보
+  - **SNS 소셜 링크**:
+    - Instagram: https://www.instagram.com/frank.photosnap/
+    - LinkedIn: https://www.linkedin.com/in/frank-oh-abb80b10/
+    - GitHub: https://github.com/kenshin579
+  - 아이콘 기반 링크 (lucide-react 아이콘 활용)
+  - 외부 링크 새 탭 열기 (`target="_blank" rel="noopener noreferrer"`)
+
+- **PortfolioCard** (`components/PortfolioCard.tsx`)
+  - 포트폴리오 아이템 카드
+  - 호버 애니메이션 (scale-105)
+  - 16:10 aspect ratio 유지
+
+- **ThemeProvider** (`components/theme-provider.tsx`)
+  - 다크/라이트 모드 전환
+  - localStorage 기반 테마 저장
+  - Next.js에서 SSR 호환성 확보 필요 (`next-themes` 라이브러리 고려)
+
+#### shadcn/ui 컴포넌트 (기존 유지)
+- Button, Card, DropdownMenu 등
+- Next.js 환경에서 재설치 필요
+
+### 4. 스타일링 시스템
+
+#### Tailwind CSS 설정
+- `tailwind.config.js` 기존 설정 이전
+- 커스텀 컬러, 폰트 설정 유지
+- 다크 모드: `class` 전략 사용
+
+#### 디자인 가이드라인 준수
+- 타이포그래피: Inter (body), Space Grotesk (headings)
+- 스페이싱: Tailwind units 2, 4, 6, 8, 12, 16, 20
+- 애니메이션: 200ms transition, subtle hover effects
+
+### 5. 빌드 및 배포
+
+#### Static Export 설정
+```javascript
+// next.config.js
+module.exports = {
+  output: 'export',  // 정적 사이트 생성
+  images: {
+    unoptimized: true  // 정적 호스팅용
+  }
+}
+```
+
+#### 빌드 명령어
+```bash
+npm run build  # Next.js static export
+npm run export # 선택적 alias
+```
+
+#### 배포 타겟
+- **Netlify** (선택) - 정적 사이트 호스팅 및 자동 배포
+  - Next.js Static Export 지원
+  - Git 연동 자동 배포 (CD)
+  - 환경 변수 관리
+  - 커스텀 도메인 설정
+  - CDN 및 전역 배포
+
+**Netlify 배포 설정**:
+```toml
+# netlify.toml
+[build]
+  command = "npm run build"
+  publish = "out"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+```
+
+## 마이그레이션 단계
+
+상세한 구현 가이드 및 작업 체크리스트는 별도 문서를 참조하세요:
+
+- **구현 가이드**: [1_nextjs_implementation.md](./1_nextjs_implementation.md)
+  - 프로젝트 구조
+  - 설정 파일 상세
+  - 컴포넌트 코드 예시
+  - 배포 설정
+
+- **작업 체크리스트**: [1_nextjs_todo.md](./1_nextjs_todo.md)
+  - Phase 1: Next.js 프로젝트 초기화
+  - Phase 2: 컴포넌트 마이그레이션
+  - Phase 3: 데이터 및 콘텐츠 처리
+  - Phase 4: 페이지 구현
+  - Phase 5: 최적화 및 테스트 (MCP Playwright)
+  - Phase 6: 클린업 및 배포 준비
+
+### 핵심 작업 흐름
+
+1. **초기화** → Next.js 14 설치, 설정 파일 구성
+2. **컴포넌트** → Header, Footer, PortfolioCard, ThemeProvider 마이그레이션
+3. **데이터** → 마크다운 파싱 로직 구현 (`lib/portfolio.ts`)
+4. **페이지** → 홈, 404 페이지 구현
+5. **테스트** → MCP Playwright E2E 테스트 (테마, 반응형, SNS 링크, 접근성)
+6. **배포** → Netlify 배포 및 클린업
+
+## 의존성 변경 사항
+
+### 제거할 패키지
+```json
+{
+  "express": "^4.x",
+  "vite": "^5.x",
+  "@vitejs/plugin-react": "^4.x",
+  "drizzle-orm": "^0.x",
+  "@neondatabase/serverless": "^0.x",
+  // 기타 서버 관련 패키지
+}
+```
+
+### 추가할 패키지
+```json
+{
+  "next": "^14.0.0",
+  "react": "^18.x",
+  "react-dom": "^18.x",
+  "next-themes": "^0.2.x",  // 테마 시스템
+  "gray-matter": "^4.x",     // 기존 사용 중
+  // 선택적: "next-mdx-remote" 또는 "@next/mdx"
+}
+```
+
+### 개발 의존성 (devDependencies)
+```json
+{
+  "netlify-cli": "^17.x"  // Netlify 로컬 테스트 및 배포
+}
+```
+
+### 유지할 패키지
+```json
+{
+  "typescript": "^5.x",
+  "tailwindcss": "^3.x",
+  "zod": "^3.x",
+  "gray-matter": "^4.x",
+  "lucide-react": "^0.x",
+  "@radix-ui/*": "^1.x",
+  "class-variance-authority": "^0.x",
+  "clsx": "^2.x",
+  "tailwind-merge": "^2.x"
+}
+```
+
+## 설정 파일 변경
+
+### 새로 생성할 파일
+- `next.config.js` - Next.js 설정 (static export)
+- `netlify.toml` - Netlify 배포 설정
+- `app/layout.tsx` - Root layout (App Router 사용 시)
+- `app/page.tsx` - 홈 페이지 (App Router 사용 시)
+- `middleware.ts` - 선택적 (리다이렉트 등)
+- **`lib/site-config.ts`** - 사이트 메타데이터 및 SNS 링크 설정
+  ```typescript
+  export const siteConfig = {
+    name: "Frank Oh Portfolio",
+    description: "Portfolio website showcasing web development projects",
+    url: "https://advenoh.pe.kr", // 실제 도메인으로 변경
+    author: {
+      name: "Frank Oh",
+      social: {
+        instagram: "https://www.instagram.com/frank.photosnap/",
+        linkedin: "https://www.linkedin.com/in/frank-oh-abb80b10/",
+        github: "https://github.com/kenshin579"
+      }
+    }
+  }
+  ```
+
+### 수정할 파일
+- `tsconfig.json` - Next.js 경로 별칭 및 설정
+- `tailwind.config.js` - content 경로 업데이트
+- `package.json` - 스크립트 및 의존성
+
+### 제거할 파일
+- `vite.config.ts`
+- `drizzle.config.ts`
+- `.replit` (Replit 설정, 필요 시 업데이트)
+
+## 비기능 요구사항
+
+### 성능
+- Lighthouse 성능 점수 90+ 목표
+- First Contentful Paint < 1.5s
+- Time to Interactive < 3s
+
+### 접근성
+- WCAG 2.1 AA 준수
+- 키보드 네비게이션 지원
+- 스크린 리더 호환성
+
+### SEO
+- 메타 태그 최적화:
+  - `title`: "Frank Oh Portfolio"
+  - `description`: Portfolio 사이트 설명
+  - `og:image`: 대표 이미지 (선택적)
+  - `og:url`: https://advenoh.pe.kr
+  - **작성자 정보**: Frank Oh
+  - **소셜 미디어 메타태그**:
+    - `twitter:creator`: @frank (있는 경우)
+    - Open Graph 프로필 정보
+- sitemap.xml 생성
+- robots.txt 설정
+- **Structured Data (JSON-LD)**:
+  - Person schema (작성자 정보)
+  - 소셜 프로필 링크 (Instagram, LinkedIn, GitHub)
+
+### 브라우저 호환성
+- 최신 2개 버전의 주요 브라우저 (Chrome, Firefox, Safari, Edge)
+- 모바일 브라우저 지원 (iOS Safari, Chrome Mobile)
+
+## 성공 기준
+
+### 필수 (MVP)
+- ✅ 포트폴리오 카드 그리드가 홈 페이지에 정상 표시
+- ✅ 다크/라이트 테마 전환 동작
+- ✅ 반응형 레이아웃 (모바일/태블릿/데스크톱)
+- ✅ `npm run build` 성공적으로 정적 파일 생성
+- ✅ **MCP Playwright 테스트 통과**: 렌더링, 테마, 반응형, 접근성 검증
+- ✅ **Netlify 배포 성공**: 프로덕션 환경에서 정상 동작
+
+### 선택적 (향후 개선)
+- 🔲 개별 포트폴리오 상세 페이지 구현
+- 🔲 마크다운 body 콘텐츠 렌더링 (MDX)
+- 🔲 이미지 갤러리 기능
+- 🔲 태그 기반 필터링
+- 🔲 검색 기능
+- 🔲 다국어 지원 (i18n)
+
+## 위험 요소 및 대응
+
+### 위험 1: 테마 시스템 SSR 충돌
+- **문제**: 서버/클라이언트 불일치로 인한 hydration 오류
+- **대응**: `next-themes` 라이브러리 사용 또는 클라이언트 전용 렌더링
+
+### 위험 2: 빌드 타임 데이터 로딩 실패
+- **문제**: 마크다운 파싱 오류로 빌드 실패
+- **대응**: 강력한 에러 핸들링 및 Zod 스키마 검증
+
+### 위험 3: shadcn/ui 컴포넌트 호환성
+- **문제**: Next.js 환경에서 일부 컴포넌트 동작 이상
+- **대응**: Next.js 공식 문서 참고하여 재설치 및 설정
+
+### 위험 4: 경로 별칭 충돌
+- **문제**: `@/` 등 기존 별칭이 Next.js 기본 설정과 충돌
+- **대응**: Next.js 표준 경로 별칭 채택 (`@/` for app root)
+
+## 참고 자료
+
+### Next.js 공식 문서
+- [Static Exports](https://nextjs.org/docs/app/building-your-application/deploying/static-exports)
+- [App Router](https://nextjs.org/docs/app)
+- [next/font](https://nextjs.org/docs/app/api-reference/components/font)
+- [next/image](https://nextjs.org/docs/app/api-reference/components/image)
+
+### 마이그레이션 가이드
+- [Migrating from Vite to Next.js](https://nextjs.org/docs/app/building-your-application/upgrading/from-vite)
+- [next-themes Documentation](https://github.com/pacocoursey/next-themes)
+
+### 배포 가이드
+- [Netlify Next.js 배포](https://docs.netlify.com/frameworks/next-js/overview/)
+- [Netlify Static Exports](https://docs.netlify.com/frameworks/next-js/#manual-configuration)
+- [netlify.toml 설정 가이드](https://docs.netlify.com/configure-builds/file-based-configuration/)
+
+### MCP 서버 활용
+- **Context7**: 라이브러리 최신 문서 참조 시 활용
+- **Playwright**: E2E 테스트 및 시각적 검증 시 활용
+
+## 타임라인 (예상)
+
+- **Week 1**: Phase 1-2 (프로젝트 초기화, 컴포넌트 마이그레이션)
+- **Week 2**: Phase 3-4 (데이터 처리, 페이지 구현)
+- **Week 3**: Phase 5-6 (최적화, 클린업, 배포)
+
+---
+
+**문서 버전**: 1.3
+**작성일**: 2025-11-07
+**최종 수정**: 2025-11-07
+**검토 필요**: 아키텍처 결정 (App Router vs Pages Router)
+
+## 변경 이력
+
+### v1.3 (2025-11-07)
+- **문서 구조 개선**:
+  - 구현 가이드 분리: `1_nextjs_implementation.md`
+  - TODO 체크리스트 분리: `1_nextjs_todo.md`
+  - PRD에서 마이그레이션 단계 상세 내용 제거, 별도 문서 참조로 변경
+- 핵심 작업 흐름 요약 추가
+
+### v1.2 (2025-11-07)
+- **SNS 소셜 링크 추가**:
+  - Instagram: https://www.instagram.com/frank.photosnap/
+  - LinkedIn: https://www.linkedin.com/in/frank-oh-abb80b10/
+  - GitHub: https://github.com/kenshin579
+- Footer 컴포넌트 신규 추가 (SNS 링크 표시)
+- Header에 SNS 링크 옵션 추가
+- `lib/site-config.ts` 설정 파일 생성 (사이트 메타데이터 및 작성자 정보)
+- SEO 섹션에 작성자 및 소셜 프로필 메타태그 추가
+- Structured Data (JSON-LD) 요구사항 추가
+
+### v1.1 (2025-11-07)
+- 배포 플랫폼: Netlify로 확정
+- MCP 서버 활용 명시:
+  - Context7: 라이브러리 최신 문서 참조
+  - Playwright: E2E 테스트 및 시각적 검증
+- Phase 5에 Playwright 기반 테스트 시나리오 추가
+- Netlify 배포 설정 가이드 추가 (netlify.toml)
+
+### v1.0 (2025-11-07)
+- 초기 PRD 작성
+- Next.js 정적 사이트 전환 요구사항 정의

--- a/docs/start/1_nextjs_todo.md
+++ b/docs/start/1_nextjs_todo.md
@@ -1,0 +1,258 @@
+# Next.js 정적 사이트 전환 - TODO 체크리스트
+
+> **관련 문서**: [1_nextjs_prd.md](./1_nextjs_prd.md) | [1_nextjs_implementation.md](./1_nextjs_implementation.md)
+
+## Phase 1: Next.js 프로젝트 초기화
+
+### 1.1 프로젝트 설정
+- [ ] Next.js 14 설치 및 초기화
+  ```bash
+  npx create-next-app@latest . --typescript --tailwind --app --no-src-dir
+  ```
+- [ ] `next.config.js` 설정 (static export)
+- [ ] `tsconfig.json` 경로 별칭 설정 (`@/*`)
+- [ ] `tailwind.config.js` 설정 (기존 테마 이전)
+- [ ] `app/globals.css` 기본 스타일 설정
+
+### 1.2 의존성 설치
+- [ ] `next-themes` 설치
+  ```bash
+  npm install next-themes
+  ```
+- [ ] `gray-matter` 설치 (마크다운 파싱)
+  ```bash
+  npm install gray-matter
+  ```
+- [ ] 기존 의존성 확인 및 유지
+  - `lucide-react`
+  - `@radix-ui/*`
+  - `zod`
+  - `tailwindcss`
+
+---
+
+## Phase 2: 컴포넌트 마이그레이션
+
+### 2.1 shadcn/ui 재설치
+- [ ] `components.json` 설정
+- [ ] shadcn/ui 초기화
+  ```bash
+  npx shadcn-ui@latest init
+  ```
+- [ ] 필요한 컴포넌트 설치
+  ```bash
+  npx shadcn-ui@latest add button card dropdown-menu
+  ```
+
+### 2.2 기본 컴포넌트 이전
+- [ ] `components/theme-provider.tsx` 생성 (next-themes 통합)
+- [ ] `components/Header.tsx` 마이그레이션
+  - 테마 토글 버튼 추가
+  - next-themes useTheme 훅 사용
+- [ ] `components/PortfolioCard.tsx` 마이그레이션
+  - Next.js Link 컴포넌트 사용
+  - 호버 애니메이션 유지
+
+### 2.3 신규 컴포넌트 생성
+- [ ] `components/Footer.tsx` 생성
+  - SNS 링크 추가 (Instagram, LinkedIn, GitHub)
+  - lucide-react 아이콘 사용
+  - `target="_blank" rel="noopener noreferrer"` 설정
+
+### 2.4 설정 파일 생성
+- [ ] `lib/site-config.ts` 생성
+  - 사이트 메타데이터
+  - 작성자 정보 (Frank Oh)
+  - SNS 링크
+
+---
+
+## Phase 3: 데이터 및 콘텐츠 처리
+
+### 3.1 포트폴리오 데이터 로더
+- [ ] `lib/portfolio.ts` 생성
+  - `getPortfolioItems()` 함수 구현
+  - `contents/website/*.md` 파일 읽기
+  - gray-matter로 frontmatter 파싱
+  - Zod 스키마 검증
+  - 파일명 기준 정렬
+
+### 3.2 데이터 검증
+- [ ] Zod 스키마 정의 (`portfolioItemSchema`)
+- [ ] frontmatter 필드 검증
+  - `site` (required, URL)
+  - `title` (optional)
+  - `description` (required)
+- [ ] 에러 핸들링 (파일 없음, 파싱 실패)
+
+---
+
+## Phase 4: 페이지 구현
+
+### 4.1 Root Layout
+- [ ] `app/layout.tsx` 생성
+  - ThemeProvider 통합
+  - Header, Footer 레이아웃
+  - 폰트 최적화 (next/font)
+    - Inter (body)
+    - Space Grotesk (heading)
+  - 메타데이터 설정
+
+### 4.2 홈 페이지
+- [ ] `app/page.tsx` 생성
+  - `getPortfolioItems()` 데이터 로드
+  - 포트폴리오 카드 그리드 렌더링
+  - 반응형 레이아웃 (1열 → 2열 → 3열)
+
+### 4.3 404 페이지
+- [ ] `app/not-found.tsx` 생성
+  - 404 메시지 및 홈 버튼
+
+### 4.4 메타데이터 최적화
+- [ ] SEO 메타태그 설정
+  - `title`: "Frank Oh Portfolio"
+  - `description`
+  - Open Graph (`og:*`)
+  - 작성자 정보
+- [ ] Structured Data (JSON-LD) - 선택적
+  - Person schema
+  - 소셜 프로필 링크
+
+---
+
+## Phase 5: 최적화 및 테스트
+
+### 5.1 성능 최적화
+- [ ] 폰트 최적화 (`next/font` 사용)
+- [ ] 이미지 최적화 검토 (필요시)
+- [ ] CSS 최적화 (Tailwind purge 확인)
+
+### 5.2 빌드 테스트
+- [ ] 로컬 빌드 실행
+  ```bash
+  npm run build
+  ```
+- [ ] `out/` 디렉토리 생성 확인
+- [ ] 정적 파일 서버 테스트
+  ```bash
+  npx serve out
+  ```
+
+### 5.3 MCP Playwright E2E 테스트
+- [ ] **포트폴리오 카드 렌더링 검증**
+  - 카드 개수 확인
+  - 제목, 설명 표시 확인
+  - 외부 링크 클릭 동작
+- [ ] **테마 전환 기능 테스트**
+  - 테마 토글 버튼 클릭
+  - 다크 모드 → 라이트 모드 전환
+  - localStorage 저장 확인
+- [ ] **반응형 레이아웃 검증**
+  - 모바일 (375px): 1열 그리드
+  - 태블릿 (768px): 2열 그리드
+  - 데스크톱 (1024px+): 3열 그리드
+- [ ] **Footer SNS 링크 동작**
+  - Instagram 링크 존재 및 URL 확인
+  - LinkedIn 링크 존재 및 URL 확인
+  - GitHub 링크 존재 및 URL 확인
+  - `target="_blank"` 속성 확인
+  - 아이콘 렌더링 확인
+- [ ] **접근성 테스트**
+  - 키보드 네비게이션 (Tab, Enter)
+  - ARIA 레이블 확인
+  - 스크린 리더 호환성
+- [ ] **스크린샷 기반 시각적 회귀 테스트**
+
+### 5.4 Netlify 로컬 테스트
+- [ ] `netlify.toml` 설정 확인
+- [ ] Netlify CLI 설치
+  ```bash
+  npm install -D netlify-cli
+  ```
+- [ ] 로컬 배포 테스트
+  ```bash
+  npx netlify dev
+  ```
+
+---
+
+## Phase 6: 클린업 및 배포 준비
+
+### 6.1 클린업 작업
+- [ ] `server/` 디렉토리 제거
+- [ ] `client/` 디렉토리 정리 (내용 이전 완료 후)
+- [ ] 미사용 파일 제거
+  - `vite.config.ts`
+  - `drizzle.config.ts`
+  - `.replit` (선택적)
+
+### 6.2 의존성 정리
+- [ ] 서버 관련 패키지 제거
+  ```bash
+  npm uninstall express vite @vitejs/plugin-react drizzle-orm @neondatabase/serverless
+  ```
+- [ ] `package.json` 스크립트 업데이트
+  - `dev`: `next dev`
+  - `build`: `next build`
+  - `start`: `next start`
+  - `lint`: `next lint`
+
+### 6.3 문서 업데이트
+- [ ] `README.md` 업데이트
+  - Next.js 프로젝트로 변경 사항 반영
+  - 빌드/개발 명령어 업데이트
+- [ ] `CLAUDE.md` 업데이트
+  - 프로젝트 구조 변경
+  - 개발 명령어 업데이트
+  - Next.js 관련 가이드 추가
+
+### 6.4 Netlify 배포 준비
+- [ ] `netlify.toml` 최종 확인
+  - `build.command`: `npm run build`
+  - `build.publish`: `out`
+  - 보안 헤더 설정
+- [ ] Git 저장소 커밋
+  ```bash
+  git add .
+  git commit -m "Migrate to Next.js static site"
+  git push
+  ```
+- [ ] Netlify 사이트 연동
+  ```bash
+  npx netlify init
+  ```
+- [ ] 프로덕션 배포
+  ```bash
+  npx netlify deploy --prod
+  ```
+
+---
+
+## 최종 검증 체크리스트
+
+### 필수 기능 (MVP)
+- [ ] ✅ 포트폴리오 카드 그리드가 홈 페이지에 정상 표시
+- [ ] ✅ 다크/라이트 테마 전환 동작
+- [ ] ✅ 반응형 레이아웃 (모바일/태블릿/데스크톱)
+- [ ] ✅ Footer SNS 링크 동작 (Instagram, LinkedIn, GitHub)
+- [ ] ✅ `npm run build` 성공적으로 정적 파일 생성
+- [ ] ✅ **MCP Playwright 테스트 통과**
+- [ ] ✅ **Netlify 배포 성공**
+
+### 성능 및 품질
+- [ ] Lighthouse 성능 점수 확인 (90+ 목표)
+- [ ] 접근성 점수 확인 (WCAG 2.1 AA)
+- [ ] SEO 메타데이터 확인
+- [ ] 브라우저 호환성 테스트 (Chrome, Firefox, Safari, Edge)
+
+---
+
+**작업 시작일**: ___________
+**완료 예정일**: ___________
+**실제 완료일**: ___________
+
+**참고사항**:
+- MCP Context7: Next.js, next-themes, shadcn/ui 최신 문서 참조 시 활용
+- MCP Playwright: 모든 E2E 테스트 시나리오 실행 시 활용
+- 각 Phase 완료 후 다음 Phase로 진행
+- 문제 발생 시 [1_nextjs_implementation.md](./1_nextjs_implementation.md) 참조


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Next.js 정적 사이트 전환을 위한 프로젝트 계획 문서를 작성했습니다.

## 생성된 문서

### 📋 [1_nextjs_prd.md](docs/start/1_nextjs_prd.md) (v1.3)
**요구사항 정의 문서**
- Express + Vite → Next.js SSG 전환 목표
- 기술 스택 및 아키텍처 분석
- Netlify 배포 전략
- SNS 링크 통합 (Instagram, LinkedIn, GitHub)
- MCP 서버 활용 전략 (Context7, Playwright)

### 🛠️ [1_nextjs_implementation.md](docs/start/1_nextjs_implementation.md)
**구현 가이드**
- 프로젝트 구조 및 디렉토리 레이아웃
- Next.js 설정 파일 (`next.config.js`, `tsconfig.json`, `tailwind.config.js`)
- 컴포넌트 코드 예시 (Layout, Header, Footer, PortfolioCard 등)
- 포트폴리오 데이터 로더 (`lib/portfolio.ts`)
- Netlify 배포 설정 (`netlify.toml`)
- MCP Playwright 테스트 전략

### ✅ [1_nextjs_todo.md](docs/start/1_nextjs_todo.md)
**작업 체크리스트 (Phase 1-6, 60+ 항목)**
- Phase 1: Next.js 프로젝트 초기화
- Phase 2: 컴포넌트 마이그레이션
- Phase 3: 데이터 및 콘텐츠 처리
- Phase 4: 페이지 구현
- Phase 5: 최적화 및 테스트 (MCP Playwright)
- Phase 6: 클린업 및 배포 준비

## 주요 특징

✅ **최소한의 구현만 포함** (향후 계획 제외)
✅ **MCP Playwright 테스트 전략**
  - 포트폴리오 카드 렌더링
  - 테마 전환 동작
  - 반응형 레이아웃 (모바일/태블릿/데스크톱)
  - Footer SNS 링크 (Instagram, LinkedIn, GitHub)
  - 접근성 (키보드, ARIA)
  - 스크린샷 기반 시각적 회귀 테스트
✅ **실제 코드 예시 포함** (복사 가능)
✅ **Netlify 배포 설정 완비**

## 변경 사항

- 📝 `docs/start/1_nextjs_prd.md` - PRD 문서 (v1.3)
- 📝 `docs/start/1_nextjs_implementation.md` - 구현 가이드
- 📝 `docs/start/1_nextjs_todo.md` - TODO 체크리스트

## 다음 단계

1. PRD 문서 검토 및 피드백
2. TODO 체크리스트 Phase 1부터 작업 시작
3. Next.js 프로젝트 초기화 및 컴포넌트 마이그레이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)