### PR TITLE
chore: Clean up legacy dependencies and refine UI components

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,54 +1,15 @@
-import Link from 'next/link'
-import { Instagram, Linkedin, Github } from 'lucide-react'
 import { siteConfig } from '@/lib/site-config'
 
 export default function Footer() {
   const currentYear = new Date().getFullYear()
 
-  const socialLinks = [
-    {
-      name: 'GitHub',
-      icon: Github,
-      url: siteConfig.author.social.github,
-      testId: 'footer-link-github',
-    },
-    {
-      name: 'LinkedIn',
-      icon: Linkedin,
-      url: siteConfig.author.social.linkedin,
-      testId: 'footer-link-linkedin',
-    },
-    {
-      name: 'Instagram',
-      icon: Instagram,
-      url: siteConfig.author.social.instagram,
-      testId: 'footer-link-instagram',
-    },
-  ]
-
   return (
     <footer className="border-t bg-background">
       <div className="container mx-auto px-4 py-8">
-        <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
+        <div className="flex flex-col items-center justify-center">
           <p className="text-sm text-muted-foreground">
             © {currentYear} {siteConfig.author.name}. All rights reserved.
           </p>
-
-          <div className="flex items-center gap-4">
-            {socialLinks.map((social) => (
-              <Link
-                key={social.name}
-                href={social.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={social.name}
-                data-testid={social.testId}
-                className="text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <social.icon className="h-5 w-5" />
-              </Link>
-            ))}
-          </div>
         </div>
       </div>
     </footer>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,10 +11,10 @@ export default function Header() {
 
   const socialLinks = [
     {
-      name: 'Instagram',
-      icon: Instagram,
-      url: siteConfig.author.social.instagram,
-      testId: 'link-instagram',
+      name: 'GitHub',
+      icon: Github,
+      url: siteConfig.author.social.github,
+      testId: 'link-github',
     },
     {
       name: 'LinkedIn',
@@ -23,10 +23,10 @@ export default function Header() {
       testId: 'link-linkedin',
     },
     {
-      name: 'GitHub',
-      icon: Github,
-      url: siteConfig.author.social.github,
-      testId: 'link-github',
+      name: 'Instagram',
+      icon: Instagram,
+      url: siteConfig.author.social.instagram,
+      testId: 'link-instagram',
     },
   ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rest-express",
+  "name": "v2-advenoh-portfolio",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rest-express",
+      "name": "v2-advenoh-portfolio",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -43,7 +43,6 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^3.6.0",
-        "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^11.13.1",
         "gray-matter": "^4.0.3",
@@ -62,22 +61,14 @@
         "tailwindcss-animate": "^1.0.7",
         "tw-animate-css": "^1.2.5",
         "vaul": "^1.1.2",
-        "wouter": "^3.3.5",
-        "ws": "^8.18.0",
         "zod": "^3.24.2",
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.15",
-        "@types/connect-pg-simple": "^7.0.3",
-        "@types/express": "4.17.21",
-        "@types/express-session": "^1.18.0",
         "@types/node": "20.16.11",
-        "@types/passport": "^1.0.16",
-        "@types/passport-local": "^1.0.38",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
-        "@types/ws": "^8.5.13",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.17",
@@ -1735,39 +1726,6 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect-pg-simple": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/connect-pg-simple/-/connect-pg-simple-7.0.3.tgz",
-      "integrity": "sha512-NGCy9WBlW2bw+J/QlLnFZ9WjoGs6tMo3LAut6mY4kK+XHzue//lpNVpAvYRpIwM969vBRAM2Re0izUvV6kt+NA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
-        "@types/express-session": "*",
-        "@types/pg": "*"
-      }
-    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -1831,109 +1789,14 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
-    "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/express-session": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.18.0.tgz",
-      "integrity": "sha512-27JdDRgor6PoYlURY+Y5kCakqp5ulC0kmf7y+QwaY+hv9jEFuQOThgkjyA53RP3jmKuBsH5GR6qEfFmvb8mwOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*"
-      }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "20.16.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
       "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@types/passport": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
-      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*"
-      }
-    },
-    "node_modules/@types/passport-local": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.38.tgz",
-      "integrity": "sha512-nsrW4A963lYE7lNTv9cr5WmiUD1ibYJvWrpE13oxApFsRt77b0RdtZvKbCdNIY4v/QZ6TRQWaDDEwV1kCTmcXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
-        "@types/passport": "*",
-        "@types/passport-strategy": "*"
-      }
-    },
-    "node_modules/@types/passport-strategy": {
-      "version": "0.2.38",
-      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
-      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
-        "@types/passport": "*"
-      }
-    },
-    "node_modules/@types/pg": {
-      "version": "8.11.6",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
-      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^4.0.1"
       }
     },
     "node_modules/@types/prop-types": {
@@ -1941,20 +1804,6 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
       "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/qs": {
-      "version": "6.9.16",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
-      "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -1976,39 +1825,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/ws": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
-      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/ansi-regex": {
@@ -2540,142 +2356,6 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/drizzle-orm": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.39.1.tgz",
-      "integrity": "sha512-2bDHlzTY31IDmrYn8i+ZZrxK8IyBD4mPZ7JmZdVDQj2tpBZXs/gxB/1kK5pSvkjxPUMNOVsTnoGkSltgjuJwcA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "@aws-sdk/client-rds-data": ">=3",
-        "@cloudflare/workers-types": ">=4",
-        "@electric-sql/pglite": ">=0.2.0",
-        "@libsql/client": ">=0.10.0",
-        "@libsql/client-wasm": ">=0.10.0",
-        "@neondatabase/serverless": ">=0.10.0",
-        "@op-engineering/op-sqlite": ">=2",
-        "@opentelemetry/api": "^1.4.1",
-        "@planetscale/database": ">=1",
-        "@prisma/client": "*",
-        "@tidbcloud/serverless": "*",
-        "@types/better-sqlite3": "*",
-        "@types/pg": "*",
-        "@types/react": ">=18",
-        "@types/sql.js": "*",
-        "@vercel/postgres": ">=0.8.0",
-        "@xata.io/client": "*",
-        "better-sqlite3": ">=7",
-        "bun-types": "*",
-        "expo-sqlite": ">=14.0.0",
-        "knex": "*",
-        "kysely": "*",
-        "mysql2": ">=2",
-        "pg": ">=8",
-        "postgres": ">=3",
-        "react": ">=18",
-        "sql.js": ">=1",
-        "sqlite3": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/client-rds-data": {
-          "optional": true
-        },
-        "@cloudflare/workers-types": {
-          "optional": true
-        },
-        "@electric-sql/pglite": {
-          "optional": true
-        },
-        "@libsql/client": {
-          "optional": true
-        },
-        "@libsql/client-wasm": {
-          "optional": true
-        },
-        "@neondatabase/serverless": {
-          "optional": true
-        },
-        "@op-engineering/op-sqlite": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@planetscale/database": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@tidbcloud/serverless": {
-          "optional": true
-        },
-        "@types/better-sqlite3": {
-          "optional": true
-        },
-        "@types/pg": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "@types/sql.js": {
-          "optional": true
-        },
-        "@vercel/postgres": {
-          "optional": true
-        },
-        "@xata.io/client": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "bun-types": {
-          "optional": true
-        },
-        "expo-sqlite": {
-          "optional": true
-        },
-        "knex": {
-          "optional": true
-        },
-        "kysely": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "postgres": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "sql.js": {
-          "optional": true
-        },
-        "sqlite3": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/drizzle-zod": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/drizzle-zod/-/drizzle-zod-0.7.0.tgz",
-      "integrity": "sha512-xgCRYYVEzRkeXTS33GSMgoowe3vKsMNBjSI+cwG1oLQVEhAWWbqtb/AAMlm7tkmV4fG/uJjEmWzdzlEmTgWOoQ==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "drizzle-orm": ">=0.36.0",
-        "zod": ">=3.0.0"
       }
     },
     "node_modules/eastasianwidth": {
@@ -3233,12 +2913,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT"
-    },
     "node_modules/motion-dom": {
       "version": "11.13.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.13.0.tgz",
@@ -3420,13 +3094,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3469,52 +3136,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
-    },
-    "node_modules/pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/pg-numeric": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
-      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pg-protocol": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
-      "integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/pg-types": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
-      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "pg-numeric": "1.0.2",
-        "postgres-array": "~3.0.1",
-        "postgres-bytea": "~3.0.0",
-        "postgres-date": "~2.1.0",
-        "postgres-interval": "^3.0.0",
-        "postgres-range": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3693,56 +3314,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
-    },
-    "node_modules/postgres-array": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
-      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postgres-bytea": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
-      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "obuf": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postgres-date": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
-      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postgres-interval": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
-      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postgres-range": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
-      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/prop-types": {
@@ -4008,15 +3579,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
-    "node_modules/regexparam": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
-      "integrity": "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -4438,7 +4000,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -4513,15 +4075,6 @@
         }
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4575,20 +4128,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wouter": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/wouter/-/wouter-3.3.5.tgz",
-      "integrity": "sha512-bx3fLQAMn+EhYbBdY3W1gw9ZfO/uchudxYMwOIBzF3HVgqNEEIT199vEoh7FLTC0Vz5+rpMO6NdFsOkGX1QQCw==",
-      "license": "Unlicense",
-      "dependencies": {
-        "mitt": "^3.0.1",
-        "regexparam": "^3.0.0",
-        "use-sync-external-store": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -4680,27 +4219,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,14 @@
 {
-  "name": "rest-express",
+  "name": "v2-advenoh-portfolio",
   "version": "1.0.0",
   "type": "module",
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "npx serve@latest out",
     "lint": "next lint",
-    "check": "tsc --noEmit",
-    "dev:old": "NODE_ENV=development tsx server/index.ts",
-    "build:old": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "db:push": "drizzle-kit push"
+    "check": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -48,7 +45,6 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^3.6.0",
-    "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^11.13.1",
     "gray-matter": "^4.0.3",
@@ -67,22 +63,14 @@
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.2.5",
     "vaul": "^1.1.2",
-    "wouter": "^3.3.5",
-    "ws": "^8.18.0",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.15",
-    "@types/connect-pg-simple": "^7.0.3",
-    "@types/express": "4.17.21",
-    "@types/express-session": "^1.18.0",
     "@types/node": "20.16.11",
-    "@types/passport": "^1.0.16",
-    "@types/passport-local": "^1.0.38",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
-    "@types/ws": "^8.5.13",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",


### PR DESCRIPTION
## Summary
- Removed legacy Vite/Express build scripts and dependencies
- Fixed start script for Next.js static export compatibility
- Cleaned up duplicate SNS links in Footer
- Reordered Header SNS links for better UX

## Changes

### Package Management
- ❌ Removed old scripts: `dev:old`, `build:old`, `db:push`
- ❌ Removed unused dependencies: `drizzle-zod`, `wouter`, `ws`
- ❌ Removed Express/Passport type definitions
- ✅ Updated package name: `rest-express` → `v2-advenoh-portfolio`
- ✅ Fixed start script: `npx serve@latest out` for static export

### UI Refinements
- ✅ Removed duplicate SNS links from Footer
- ✅ Reordered Header SNS: GitHub → LinkedIn → Instagram
- ✅ Footer now shows only copyright text

## Test Plan
- [x] Build succeeds: `npm run build`
- [x] Start script works: `npm run start`
- [x] Type checking passes: `npm run check`
- [x] Visual verification with Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)