### PR TITLE
feat: 포트폴리오 항목 표시 순서 변경

### DIFF
--- a/contents/website/ai-chatbot/index.md
+++ b/contents/website/ai-chatbot/index.md
@@ -12,7 +12,7 @@ stack:
   - Kubernetes
   - Helm
 ext: .py
-order: 2
+order: 7
 status_en: live
 status_ko: 운영 중
 year_en: 2024 — now

--- a/contents/website/investment-blog/index.md
+++ b/contents/website/investment-blog/index.md
@@ -7,7 +7,7 @@ stack:
   - Markdown
   - Netlify
 ext: .md
-order: 4
+order: 6
 status_en: live
 status_ko: 운영 중
 year_en: 2024 — now

--- a/contents/website/it-blog/index.md
+++ b/contents/website/it-blog/index.md
@@ -7,7 +7,7 @@ stack:
   - Markdown
   - Netlify
 ext: .md
-order: 3
+order: 5
 status_en: live
 status_ko: 운영 중
 year_en: 2020 — now

--- a/contents/website/markora/index.md
+++ b/contents/website/markora/index.md
@@ -10,7 +10,7 @@ stack:
   - KaTeX
   - Mermaid
 ext: .kt
-order: 6
+order: 2
 status_en: live
 status_ko: 운영 중
 year_en: 2026 — now

--- a/contents/website/status/index.md
+++ b/contents/website/status/index.md
@@ -9,7 +9,7 @@ stack:
   - GitHub Actions
   - Netlify
 ext: .ts
-order: 5
+order: 4
 status_en: live
 status_ko: 운영 중
 year_en: 2026 — now

--- a/contents/website/summora/index.md
+++ b/contents/website/summora/index.md
@@ -13,7 +13,7 @@ stack:
   - Kubernetes
   - Helm
 ext: .go
-order: 7
+order: 3
 status_en: live
 status_ko: 운영 중
 year_en: 2026 — now


### PR DESCRIPTION
## Summary
- 포트폴리오 항목의 표시 순서를 아래와 같이 변경 (각 `contents/website/*/index.md`의 `order` 값 조정)

| order | 항목 |
|---|---|
| 1 | InspireMe |
| 2 | Markora |
| 3 | Summora |
| 4 | Advenoh Status |
| 5 | IT Blog |
| 6 | Investment Insights |
| 7 | AI Chatbot |

## Test plan
- [ ] `npm run dev` 로컬에서 홈 포트폴리오 그리드가 위 순서로 표시되는지 확인
- [ ] 배포 후 운영 환경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)