### PR TITLE
feat: BLOG POSTS 카드를 IT+투자 블로그 전체 글 수 합계로 변경

### DIFF
--- a/components/profile/ProfileShell.tsx
+++ b/components/profile/ProfileShell.tsx
@@ -38,6 +38,7 @@ type ProfileShellProps = {
     it: WritingItem[]
     investment: WritingItem[]
     latest: WritingItem[]
+    totals: { it: number; investment: number }
   }
   portfolioItems: PortfolioItem[]
   github: GithubContrib
@@ -55,7 +56,7 @@ export function ProfileShell({
 }: ProfileShellProps) {
   const status = useLiveStatus(initialStatus)
   const writing = useLiveWriting(initialWriting)
-  const stats = computeHeroStats(status, github, writing.it)
+  const stats = computeHeroStats(status, github, writing.totals.it + writing.totals.investment)
   const activeSection = useScrollSpy(SPY_SECTIONS as unknown as string[])
 
   useKeyboardNav({ itemCount: portfolioItems.length })

--- a/hooks/useLiveWriting.ts
+++ b/hooks/useLiveWriting.ts
@@ -37,6 +37,7 @@ export function useLiveWriting(initial: {
   it: WritingItem[]
   investment: WritingItem[]
   latest: WritingItem[]
+  totals: { it: number; investment: number }
 }) {
   const [data, setData] = useState(initial)
 
@@ -67,6 +68,7 @@ export function useLiveWriting(initial: {
           it: it.slice(0, 5),
           investment: inv.slice(0, 5),
           latest,
+          totals: { it: it.length, investment: inv.length },
         })
       } catch {
         // 실패 시 initialData 유지

--- a/lib/home-data.ts
+++ b/lib/home-data.ts
@@ -25,6 +25,7 @@ export async function loadHomeData(locale: Locale) {
       it: writingSections.it,
       investment: writingSections.investment,
       latest: latestPosts,
+      totals: writingSections.totals,
     },
     readme,
   }

--- a/lib/i18n/en.ts
+++ b/lib/i18n/en.ts
@@ -86,7 +86,7 @@ export const en = {
   },
   stats: {
     servicesUp: 'services up',
-    blogPosts: 'blog posts',
+    blogPosts: 'total blog posts',
   },
   commits: {
     less: 'Less',

--- a/lib/i18n/ko.ts
+++ b/lib/i18n/ko.ts
@@ -88,7 +88,7 @@ export const ko: Dict = {
   },
   stats: {
     servicesUp: '서비스 정상',
-    blogPosts: '블로그 글',
+    blogPosts: '전체 블로그 글',
   },
   commits: {
     less: '적음',

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -1,6 +1,5 @@
 import type { StatusSnapshot } from './status'
 import type { GithubContrib } from './github'
-import type { WritingItem } from './writing'
 
 export type HeroStats = {
   servicesUp: { up: number; total: number }
@@ -16,12 +15,12 @@ export type HeroStats = {
 export function computeHeroStats(
   status: StatusSnapshot,
   github: GithubContrib,
-  blogItems: WritingItem[]
+  blogPostsTotal: number
 ): HeroStats {
   return {
     servicesUp: { up: status.summary.up, total: status.summary.total },
     commits26w: github.totalContributions,
     uptime90d: status.summary.uptime90d,
-    blogPosts: blogItems.length,
+    blogPosts: blogPostsTotal,
   }
 }

--- a/lib/writing.ts
+++ b/lib/writing.ts
@@ -95,6 +95,7 @@ export async function getWritingSections() {
   return {
     it: itBundle.items.slice(0, 5),
     investment: invBundle.items.slice(0, 5),
+    totals: { it: itBundle.items.length, investment: invBundle.items.length },
   }
 }
 


### PR DESCRIPTION
## Summary
- `BLOG POSTS` 통계 카드가 상위 5개로 잘린 IT 글 배열 길이를 사용해 항상 최대 5로 고정되던 문제 수정
- `getWritingSections()`가 슬라이스 전 원본 개수(`totals: { it, investment }`)를 함께 반환하도록 변경
- Hero 통계가 IT + 투자 블로그 전체 글 수 합계를 표시 (서버 빌드 시점 + 클라이언트 RSS 재fetch 시 갱신)
- 라벨 변경: `blog posts` → `total blog posts` / `블로그 글` → `전체 블로그 글`

## Test plan
- [ ] `npm run check` 타입 체크 통과
- [ ] `npm run dev` 후 Hero `TOTAL BLOG POSTS` 카드가 IT+INV 합계로 표시되는지 확인
- [ ] EN/KO 라벨이 각각 "total blog posts" / "전체 블로그 글"로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)