### PR TITLE
fix: 모바일 본문 우측 잘림(가로 오버플로) 해소

### DIFF
--- a/components/profile/ProfileShell.tsx
+++ b/components/profile/ProfileShell.tsx
@@ -80,7 +80,7 @@ export function ProfileShell({
 
             <div
               ref={contentRef}
-              className="flex-1 px-4 sm:px-6 pt-6 pb-16 space-y-[var(--profile-space-section)]"
+              className="min-w-0 flex-1 px-4 sm:px-6 pt-6 pb-16 space-y-[var(--profile-space-section)]"
             >
               <Hero stats={stats} github={github} status={status} readme={readme} t={t} />
 


### PR DESCRIPTION
## Summary
- 모바일에서 본문 오른쪽이 잘려 보이던 문제 수정 (프로젝트 카드 우측, readme 행의 Memcached·Jenkins 등)
- 원인: 본문 컬럼 `div.flex-1`이 flex 자식의 기본값 `min-width: auto` 때문에 콘텐츠 최소폭 아래로 줄어들지 못하고 뷰포트보다 넓어짐 → 부모 `main`의 `overflow-x-hidden`이 넘친 우측을 클립
- 수정: 해당 컬럼에 `min-w-0` 추가하여 뷰포트 폭에 맞게 축소되도록 함

## 검증
- 라이브 사이트를 모바일 폭(≈500px)으로 측정: 본문 컬럼 524px → 뷰포트 초과
- `min-w-0` 적용 시 524 → 500px로 일치, 뷰포트를 벗어난 요소 39개 → 0개

## Test plan
- [ ] 실제 모바일(또는 DevTools 모바일 뷰)에서 본문 우측 잘림이 사라졌는지 확인
- [ ] 프로젝트 카드 그리드가 한 줄로 정상 표시되는지 확인
- [ ] 데스크톱 레이아웃(사이드바/라인 거터/우측 레일)에 회귀가 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)